### PR TITLE
Feat: Add Matron File support

### DIFF
--- a/packages/matron/src/create.ts
+++ b/packages/matron/src/create.ts
@@ -73,11 +73,8 @@ async function create(options: CreateOptions) {
   }
   const templateCacheDir = path.join(appRoot.path, 'cache/templates/src');
   if (isDev) {
-    templatePath = path.join(
-      appRoot.path,
-      'node_modules/@matron/schematics/node_modules/@matron',
-      getTemplateLocation(templateName)
-    );
+    templatePath = path.join(appRoot.path, 'node_modules/@matron', getTemplateLocation(templateName));
+    console.log('herreeeeeee ???', templatePath);
   } else {
     templatePath = path.join(appRoot.path, 'cache', getTemplateLocation(templateName));
     if (!p) {

--- a/packages/schematics/src/collection/create/create.schematic.ts
+++ b/packages/schematics/src/collection/create/create.schematic.ts
@@ -11,6 +11,10 @@ import {
 } from '@angular-devkit/schematics';
 import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
 import path from 'path';
+import { readFileSync } from 'fs';
+import { parser } from '../../matron-file/parser';
+// import { executeTask } from '../add';
+// import { executeTask } from ';
 
 export interface CreateSchema {
   name: string;
@@ -24,6 +28,19 @@ export function create(options: CreateSchema): Rule {
     const { projectPath, templatePath, skipInstall } = options;
     const templateSource = apply(url(templatePath), [move(projectPath)]);
 
+    // const matronFile = readFileSync(path.join(templatePath, './matron.txt'), 'utf8');
+    console.log('template path', templatePath, path.join(templatePath, './Matronfile'));
+    const matronFile = readFileSync(path.join(templatePath, './Matronfile'), 'utf8');
+    console.log('matronFile', matronFile);
+    const commands = parser(matronFile);
+    // commands.forEach(command => {
+    //   if (command.cmd === 'RUN') {
+    //     const cmd = command.args[0].split(' ');
+    //     const exec = cmd.shift();
+    //     if (exec) executeTask({ command: exec, args: cmd });
+    //   }
+    // });
+    console.log('commands', commands);
     // Need to extract the relative path of the cwd because of https://github.com/angular/angular-cli/issues/13526
     const curDir = process.cwd();
     const dirRelativePath = path.relative(curDir, projectPath);

--- a/packages/schematics/src/matron-file/parser.ts
+++ b/packages/schematics/src/matron-file/parser.ts
@@ -28,8 +28,9 @@ function getCommand(line: string) {
 }
 
 function parseRun(line: string) {
-  const reg = new RegExp(/(?<cmd>^\w+)\s+['|"](?<args>.*)['|"]/);
+  const reg = new RegExp(/(?<cmd>^\w+)\s+(?<args>.*)/);
   const match = reg.exec(line);
+  console.log('match', match)
   if (match && match.groups) {
     return { cmd: match.groups.cmd as 'RUN', args: [match.groups.args] };
   } else {

--- a/packages/schematics/src/matron-file/parser.ts
+++ b/packages/schematics/src/matron-file/parser.ts
@@ -1,0 +1,97 @@
+interface Command {
+  cmd: keyof typeof CommandType;
+  args: string[];
+}
+
+enum CommandType {
+  COPY = 'COPY',
+  RUN = 'RUN',
+  WORKDIR = 'WORKDIR'
+}
+
+function getCommand(line: string) {
+  const commandType = getCommandType(line);
+  switch (commandType) {
+    case CommandType.COPY: {
+      return parseCopy(line);
+    }
+    case CommandType.RUN: {
+      return parseRun(line);
+    }
+    case CommandType.WORKDIR: {
+      return parseWorkdir(line);
+    }
+    default: {
+      throw new Error(`Command ${commandType} unknown`);
+    }
+  }
+}
+
+function parseRun(line: string) {
+  const reg = new RegExp(/(?<cmd>^\w+)\s+['|"](?<args>.*)['|"]/);
+  const match = reg.exec(line);
+  if (match && match.groups) {
+    return { cmd: match.groups.cmd as 'RUN', args: [match.groups.args] };
+  } else {
+    throw new Error('Unable to parse RUN command');
+  }
+}
+
+function parseCopy(line: string) {
+  const reg = new RegExp(/(?<cmd>^\w+)\s+(?<args>.*)/);
+  const match = reg.exec(line);
+  if (match && match.groups) {
+    return { cmd: match.groups.cmd as 'COPY', args: match.groups.args.split(/\s+/) };
+  } else {
+    throw new Error('Unable to parse COPY command');
+  }
+}
+
+function parseWorkdir(line: string) {
+  const reg = new RegExp(/(?<cmd>^\w+)\s+(?<args>.*)/);
+  const match = reg.exec(line);
+  if (match && match.groups) {
+    return { cmd: match.groups.cmd as 'WORKDIR', args: match.groups.args.split(/\s+/) };
+  } else {
+    throw new Error('Unable to parse WORKDIR command');
+  }
+}
+
+export function parser(content: string) {
+  const cmds: Command[] = [];
+  return content
+    .split('\n')
+    .map(formatLine)
+    .reduce((acc, line, index) => {
+      if (isValidCommand(line)) {
+        try {
+          acc.push(getCommand(line));
+        } catch (err) {
+          console.error(`Error at line ${index + 1}`);
+          throw err;
+        }
+      }
+      return acc;
+    }, cmds);
+}
+
+function isEmptyLine(line: string) {
+  return line === '';
+}
+
+function formatLine(line: string) {
+  return line.trim();
+}
+function isValidCommand(line: any) {
+  return !isEmptyLine(line) && !isComment(line);
+}
+
+function isComment(line: string) {
+  return line.startsWith('#');
+}
+
+function getCommandType(line: string) {
+  const reg = new RegExp(/^\w+/, 'g');
+  const match = line.match(reg);
+  if (match) return match[0] as CommandType;
+}

--- a/packages/templates/src/typescript/Matronfile
+++ b/packages/templates/src/typescript/Matronfile
@@ -1,0 +1,4 @@
+RUN npx mkdirp ${PROJECT_PATH}
+WORKDIR ${PROJECT_PATH}
+# RUN 'npm init -y'
+

--- a/packages/templates/src/typescript/files/nodemon.json
+++ b/packages/templates/src/typescript/files/nodemon.json
@@ -1,0 +1,7 @@
+{
+  "watch": ["src/**/*.ts"],
+  "execMap": {
+    "ts": "ts-node",
+    "js": "node"
+  }
+}

--- a/packages/templates/src/typescript/files/src/index.ts
+++ b/packages/templates/src/typescript/files/src/index.ts
@@ -1,0 +1,5 @@
+export function main() {
+  console.log('Hello World!');
+}
+
+main();

--- a/packages/templates/src/typescript/files/tsconfig.json
+++ b/packages/templates/src/typescript/files/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2015",
+    "module": "commonjs",
+    "sourceMap": true,
+    "declaration": true,
+    "outDir": "dist",
+    "strict": true,
+    "removeComments": true,
+    "esModuleInterop": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
# Summary

**Providing the ability to use a domain specific language similar to a Dockerfile in order to execute a sequence creating a new project.**

# Basic example

- Create a Matronfile
- Define the steps to create your base project
- The CLI then outputs a new recipe aimed to be used to kick off subsequent projects

# Motivation

The idea is to provide a standard and flexible way to start any new project.

# Detailed design

TBD

# Drawbacks
 
TBD

